### PR TITLE
ci: create semi-automatic release pipeline gated via version tags

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,29 @@
+name: Build Release
+# On tag push only release CI pipeline. Generates a release when a tag is pushed to origin.
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  create_version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - name: Create NMSSaveEditor Release
+        uses: papeloto/action-zip@v1
+        with:
+          # Files to be included in release. Separated by empty space.
+          files: NMSSaveEditor.exe NMSSaveEditor.jar
+          recursive: false
+          dest: NMSSaveEditor.zip
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ github.workspace }}/*.zip
+          # Include the changelog in the GitHub Releases page.
+          body_path: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: goatfungus/NMSSaveEditor


### PR DESCRIPTION
fixes #432

## Summary

Creates a CI pipeline to automatically publish a release provided:

- You have created a tag at the relevant commit.
- Have a github token / personal access token (best to do this for this CI).

*Small additional benefit:* Since the save editor checks for latest release small QoL for users to be redirected to your releases page with the changelog in view. 

### Workflow 

The action zips up both the saveditor *.exe and *.jar into `NMSSaveEditor.zip` and utilizes the CHANGELOG.md in the root of the repo as the release notes when published.

Simple state the tag for release i.e. v1.8.3 at your next commit and this CI will create a release with your changelog. 

I opted to leave out the `version.txt` as it wouldn't really be relevant. 